### PR TITLE
correct team name in code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behaviour may be
-reported by contacting [a member of the project team](https://github.com/orgs/HotelsDotCom/teams/beeju-committers/members). All
+reported by contacting [a member of the project team](https://github.com/orgs/HotelsDotCom/teams/neaps-committers/members). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Minor change but this project showed up in an unrelated search so would be nice to correct.